### PR TITLE
fix: 게임 시작 시 사용자 초기 등록으로 중복 키 문제 해결

### DIFF
--- a/src/main/java/backend/csquiz/entity/User.java
+++ b/src/main/java/backend/csquiz/entity/User.java
@@ -21,5 +21,6 @@ public class User {
     @Column(nullable = false, unique = true)
     private String nickname;
 
+    @Column(nullable = false)
     private int score;
 }

--- a/src/main/java/backend/csquiz/service/GameService.java
+++ b/src/main/java/backend/csquiz/service/GameService.java
@@ -37,9 +37,12 @@ public class GameService {
     // 게임 시작
     public GameStartResponseDTO startGame(String nickname, String difficulty) {
         // 닉네임 중복 확인
-        if(userService.findByNickname(nickname).isPresent()){
+        if(userService.findByNickname(nickname).isPresent()) {
             throw new IllegalArgumentException("이미 사용 중인 닉네임입니다.");
         }
+
+        // 새로운 유저 등록(초기 점수 0)
+        userService.saveScore(nickname, 0);
 
         List<Long> questionIds = getQuestionsByDifficulty(difficulty).stream()
                 .map(Question::getId)


### PR DESCRIPTION
- findByNickname()에서 존재하지 않는다고 판단한 후 insert하려다 중복 오류 발생
- 게임 시작 시 사용자 닉네임과 초기 점수(0)를 미리 저장하여 중복 키 예외 방지
- `saveScore()` 메서드에서 `orElseGet()`을 활용하여 존재하지 않는 사용자 자동 생성