### PR TITLE
feat: 게임 도중 동일 닉네임 사용 방지를 위한 Redis 캐싱 추가 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ repositories {
 }
 
 dependencies {
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/backend/csquiz/controller/GameController.java
+++ b/src/main/java/backend/csquiz/controller/GameController.java
@@ -22,33 +22,29 @@ public class GameController {
 
     // 게임 시작
     @PostMapping("/start")
-    public GameStartResponseDTO startGame(@RequestBody StartGameRequestDTO request) {
-        return gameService.startGame(request.getNickname(), request.getDifficulty());
+    public ResponseEntity<GameStartResponseDTO> startGame(@RequestBody StartGameRequestDTO request) {
+        GameStartResponseDTO response = gameService.startGame(request.getNickname(), request.getDifficulty());
+        return ResponseEntity.ok(response);
     }
 
     // 게임의 문제 조회
     @GetMapping("/{gameId}/questions")
-    public List<QuestionResponseDTO> getQuestionByGame(@PathVariable String gameId) {
-        return gameService.getQuestionsByGame(gameId);
+    public ResponseEntity<List<QuestionResponseDTO>> getQuestionByGame(@PathVariable String gameId) {
+        List<QuestionResponseDTO> response = gameService.getQuestionsByGame(gameId);
+        return ResponseEntity.ok(response);
     }
 
     // 정답 확인
     @PostMapping("/{gameId}/answer")
-    public CheckAnswerResponseDTO checkAnswer(@PathVariable String gameId, @RequestBody CheckAnswerRequestDTO request) {
+    public ResponseEntity<CheckAnswerResponseDTO> checkAnswer(@PathVariable String gameId, @RequestBody CheckAnswerRequestDTO request) {
         boolean isCorrect = gameService.checkAnswer(gameId, request.getQuestionId(), request.getAnswer());
-        return new CheckAnswerResponseDTO(isCorrect);
+        return ResponseEntity.ok(new CheckAnswerResponseDTO(isCorrect));
     }
 
     // 게임 종료
     @PostMapping("/{gameId}/end")
-    public GameFinishResponseDTO finishGame(@PathVariable String gameId) {
-        return gameService.finishGame(gameId);
-    }
-
-    // 게임 도중 나갈 시 게임 데이터 삭제
-    @PostMapping("/{gameId}/leave")
-    public ResponseEntity<String> leaveGame(@PathVariable String gameId){
-        gameService.deleteGame(gameId);
-        return ResponseEntity.ok("게임이 정상적으로 삭제되었습니다.");
+    public ResponseEntity<GameFinishResponseDTO> finishGame(@PathVariable String gameId) {
+        GameFinishResponseDTO response = gameService.finishGame(gameId);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/backend/csquiz/global/RedisConfig.java
+++ b/src/main/java/backend/csquiz/global/RedisConfig.java
@@ -1,0 +1,54 @@
+package backend.csquiz.global;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+
+/**
+ * Redis 설정 클래스
+ * Spring Boot 애플리케이션에서 Redis를 사용하기 위한 설정
+ */
+@Configuration
+public class RedisConfig {
+    /**
+     * Redis 연결 팩토리 생성
+     * Lettuce를 이용하여 Redis 서버와 연결하는 ConnectionFactory를 생성합니다.
+     *
+     * @return RedisConnectionFactory - Redis 연결을 위한 팩토리 객체
+     */
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory(){
+        return new LettuceConnectionFactory();
+    }
+
+    /**
+     * RedisTemplate 설정
+     * Redis와 데이터를 주고받기 위한 템플릿을 설정합니다.
+     * Redis에서 key와 value를 String 타입으로 저장할 때 사용됩니다.
+     *
+     * @param redisConnectionFactory Redis 연결 팩토리
+     * @return RedisTemplate<String, String> - Redis 연산을 위한 템플릿 객체
+     */
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory redisConnectionFactory){
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
+        return template;
+    }
+
+    /**
+     * StringRedisTemplate 설정
+     * Redis에서 문자열 데이터를 다룰 때 편리하게 사용할 수 있는 템플릿을 생성합니다.
+     *
+     * @param redisConnectionFactory Redis 연결 팩토리
+     * @return StringRedisTemplate - 문자열 기반 Redis 연산을 위한 템플릿 객체
+     */
+    @Bean
+    public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory redisConnectionFactory){
+        return new StringRedisTemplate(redisConnectionFactory);
+    }
+}

--- a/src/main/java/backend/csquiz/service/UserService.java
+++ b/src/main/java/backend/csquiz/service/UserService.java
@@ -4,21 +4,43 @@ import backend.csquiz.entity.User;
 import backend.csquiz.repository.UserRepository;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class UserService {
     private final UserRepository userRepository;
+    public final StringRedisTemplate redisTemplate;
 
 
-    public UserService(UserRepository userRepository) {
+    public UserService(UserRepository userRepository, StringRedisTemplate redisTemplate) {
         this.userRepository = userRepository;
+        this.redisTemplate = redisTemplate;
     }
 
     // 닉네임으로 사용자 조회
     public Optional<User> findByNickname(String nickname){
         return userRepository.findByNickname(nickname);
+    }
+
+    // 게임 시작 시 닉네임 중복 체크
+    public boolean isUserInGame(String nickname){
+        return redisTemplate.hasKey("game:user:" + nickname);
+    }
+
+    // 게임 시작 시 닉네임을 Redis 에 저장
+    public void markUserAsInGame(String nickname){
+        ValueOperations<String, String> ops = redisTemplate.opsForValue();
+        ops.set("game:user:" + nickname, "IN_GAME", 10, TimeUnit.MINUTES); // TTL 10분 설정
+    }
+
+    // 게임 종료 시 Redis 에서 삭제
+    public void removeUserFromGame(String nickname){
+        redisTemplate.delete("game:user:" + nickname);
+
     }
 
     // 사용자 점수 저장


### PR DESCRIPTION
- DB에 정보를 저장하기 전 동일 닉네임 사용 방지 
- 게임 진행 중 동일 닉네임이 사용되지 않도록 Redis를 활용한 중복 체크 기능 구현
- 닉네임 생성 시 Redis에 key-value 형태(`game:user:<닉네임>`)로 저장
- 게임 종료 후 해당 닉네임 데이터를 Redis에서 자동으로 삭제 처리